### PR TITLE
Integración de referencias MVC, ejecutable y funcionalidad para abrir VistaDeReportes desde Reportes

### DIFF
--- a/codigo/componentes/reporteador/Exe_reporteador/Ejecucion_Componente_Reporteador/Ejecucion_Componente_Reporteador.csproj
+++ b/codigo/componentes/reporteador/Exe_reporteador/Ejecucion_Componente_Reporteador/Ejecucion_Componente_Reporteador.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Capa_Vista_Reporteador">
+      <HintPath>..\..\reporteador\Capa_Vista_Reporteador\bin\Debug\Capa_Vista_Reporteador.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/codigo/componentes/reporteador/Exe_reporteador/Ejecucion_Componente_Reporteador/Program.cs
+++ b/codigo/componentes/reporteador/Exe_reporteador/Ejecucion_Componente_Reporteador/Program.cs
@@ -16,7 +16,7 @@ namespace Ejecucion_Componente_Reporteador
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new Form1());
+            Application.Run(new Capa_Vista_Reporteador.Reportes());
         }
     }
 }

--- a/codigo/componentes/reporteador/reporteador/Capa_Controlador_Reporteador/Capa_Controlador_Reporteador.csproj
+++ b/codigo/componentes/reporteador/reporteador/Capa_Controlador_Reporteador/Capa_Controlador_Reporteador.csproj
@@ -31,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Capa_Modelo_Reporteador">
+      <HintPath>..\Capa_Modelo_Reporteador\bin\Debug\Capa_Modelo_Reporteador.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -41,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Controlador.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/codigo/componentes/reporteador/reporteador/Capa_Controlador_Reporteador/Controlador.cs
+++ b/codigo/componentes/reporteador/reporteador/Capa_Controlador_Reporteador/Controlador.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Capa_Controlador_Reporteador
+{
+    class Controlador
+    {
+    }
+}

--- a/codigo/componentes/reporteador/reporteador/Capa_Modelo_Reporteador/Capa_Modelo_Reporteador.csproj
+++ b/codigo/componentes/reporteador/reporteador/Capa_Modelo_Reporteador/Capa_Modelo_Reporteador.csproj
@@ -41,7 +41,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Conexion.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Sentencias.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/codigo/componentes/reporteador/reporteador/Capa_Modelo_Reporteador/Conexion.cs
+++ b/codigo/componentes/reporteador/reporteador/Capa_Modelo_Reporteador/Conexion.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Capa_Modelo_Reporteador
+{
+    class Conexion
+    {
+    }
+}

--- a/codigo/componentes/reporteador/reporteador/Capa_Modelo_Reporteador/Sentencias.cs
+++ b/codigo/componentes/reporteador/reporteador/Capa_Modelo_Reporteador/Sentencias.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Capa_Modelo_Reporteador
+{
+    class Sentencias
+    {
+    }
+}

--- a/codigo/componentes/reporteador/reporteador/Capa_Vista_Reporteador/Capa_Vista_Reporteador.csproj
+++ b/codigo/componentes/reporteador/reporteador/Capa_Vista_Reporteador/Capa_Vista_Reporteador.csproj
@@ -31,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Capa_Controlador_Reporteador">
+      <HintPath>..\Capa_Controlador_Reporteador\bin\Debug\Capa_Controlador_Reporteador.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -57,13 +60,13 @@
       <DependentUpon>VistaDeReportes.cs</DependentUpon>
     </Compile>
   </ItemGroup>
-<ItemGroup>
-  <EmbeddedResource Include="VistaDeReportes.resx">
-    <DependentUpon>VistaDeReportes.cs</DependentUpon>
-  </EmbeddedResource>
-  <EmbeddedResource Include="Reportes.resx">
-    <DependentUpon>Reportes.cs</DependentUpon>
-  </EmbeddedResource>
-</ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="VistaDeReportes.resx">
+      <DependentUpon>VistaDeReportes.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Reportes.resx">
+      <DependentUpon>Reportes.cs</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/codigo/componentes/reporteador/reporteador/Capa_Vista_Reporteador/Reportes.Designer.cs
+++ b/codigo/componentes/reporteador/reporteador/Capa_Vista_Reporteador/Reportes.Designer.cs
@@ -118,6 +118,7 @@ namespace Capa_Vista_Reporteador
             this.Btn_ver_reporte.TabIndex = 7;
             this.Btn_ver_reporte.Text = "Ver reporte";
             this.Btn_ver_reporte.UseVisualStyleBackColor = false;
+            this.Btn_ver_reporte.Click += new System.EventHandler(this.Btn_ver_reporte_Click);
             // 
             // Btn_ruta_reporte
             // 

--- a/codigo/componentes/reporteador/reporteador/Capa_Vista_Reporteador/Reportes.cs
+++ b/codigo/componentes/reporteador/reporteador/Capa_Vista_Reporteador/Reportes.cs
@@ -21,5 +21,14 @@ namespace Capa_Vista_Reporteador
         {
 
         }
+
+        private void Btn_ver_reporte_Click(object sender, EventArgs e)
+        {
+            // Instancia para ver reportes
+            VistaDeReportes frm = new VistaDeReportes();
+
+            // Mostrarlo como ventana aparte
+            frm.Show();
+        }
     }
 }


### PR DESCRIPTION
Se han agregado referencias MVC y ejecutable, además se ha implementado la funcionalidad para que al presionar el botón existente en Reportes se abra VistaDeReportes.

Referencias
- Capa_Vista_Reporteador: Se agregó como referencia Capa_Controlador_Reporteador
- Capa_Controlador_Reporteador: Se agregó como referencia Capa_Modelo_Reporteador
- Ejecutable: Se agregó como referencia Capa_Vista_Reporteador

Funcionalidad
- Al hacer clic en el botón "Ver Reporte" de Reportes, se abre VistaDeReportes como ventana independiente.
- Ambos formularios permanecen abiertos al mismo tiempo.

**Paula Leonardo - 06/09/2025**
