### PR TITLE
Metodo para busqueda de reportes

### DIFF
--- a/codigo/componentes/reporteador/reporteador/Capa_Modelo_Reporteador/Sentencias.cs
+++ b/codigo/componentes/reporteador/reporteador/Capa_Modelo_Reporteador/Sentencias.cs
@@ -30,5 +30,33 @@ namespace Capa_Modelo_Reporteador
             }
         }
         // Fin de código de: María Morales con carné: 0901-22-1226 en la fecha de: 11/09/2025
+
+        // Inicio de código de: Rocio Lopez con carné: 9959-23-740 en la fecha de: 11/09/2025
+
+        public DataTable ObtenerReportes()
+        {
+            DataTable tabla = new DataTable();
+
+            try
+            {
+                using (OdbcConnection con = Conexion.ObtenerConexion())
+                {
+                    string sql = "SELECT pk_id_reportes, titulo_reportes, ruta_reportes, fecha_reportes FROM tbl_reportes";
+                    OdbcDataAdapter da = new OdbcDataAdapter(sql, con);
+                    da.Fill(tabla);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Aquí mostrara mensaje de error 
+                Console.WriteLine("Error al obtener reportes: " + ex.Message);
+            }
+
+            return tabla;
+        }
+
+
+        // Fin de código de: Rocio Lopez con carné: 9959-23-740 en la fecha de: 11/09/2025
+
     }
 }


### PR DESCRIPTION
Se agrego el método de búsqueda de reportes en Sentencias en Capa_Modelo_Reporteador.
Junto a un try/catch para captura de errores

Rocio López 11/09/25