### PR TITLE
Corrección de uso de clase Conexión en métodos de Sentencias

### DIFF
--- a/codigo/componentes/reporteador/reporteador/Capa_Modelo_Reporteador/Sentencias.cs
+++ b/codigo/componentes/reporteador/reporteador/Capa_Modelo_Reporteador/Sentencias.cs
@@ -11,26 +11,28 @@ namespace Capa_Modelo_Reporteador
     //Clase Publica
     public class Sentencias
     {
-        //Bárbara Saldaña 
+        //Inicio de código de: Bárbara Saldaña 
         //InsertarReporte -> Método para poder insertar reportes
     public void InsertarReporte(string titulo, string ruta, DateTime fecha)
+          {
+            Conexion cn = new Conexion();
+            using (OdbcConnection con = cn.conexion())
             {
-                using (OdbcConnection con = Conexion.ObtenerConexion())
-                {
-                    string sql = "INSERT INTO tbl_reportes (titulo_reportes, ruta_reportes, fecha_reportes) VALUES (?,?,?)";
-                    OdbcCommand cmd = new OdbcCommand(sql, con);
-                    cmd.Parameters.AddWithValue("titulo", titulo);
-                    cmd.Parameters.AddWithValue("ruta", ruta);
-                    cmd.Parameters.AddWithValue("fecha", fecha);
-                    cmd.ExecuteNonQuery();
-                }
-            }
-    }
+                string sql = "INSERT INTO tbl_reportes (titulo_reportes, ruta_reportes, fecha_reportes) VALUES (?,?,?)";
+                OdbcCommand cmd = new OdbcCommand(sql, con);
+                cmd.Parameters.AddWithValue("titulo", titulo);
+                cmd.Parameters.AddWithValue("ruta", ruta);
+                cmd.Parameters.AddWithValue("fecha", fecha);
+                cmd.ExecuteNonQuery();
+            }
+          }
+        //Fin de código de: Bárbara Saldaña
 
         // Inicio de código de: María Morales con carné: 0901-22-1226 en la fecha de: 11/09/2025
         public void Modificar_Ruta(int id, string nuevaRuta)
         {
-            using (OdbcConnection con = Conexion.ObtenerConexion())
+            Conexion cn = new Conexion();
+            using (OdbcConnection con = cn.conexion())
             {
                 string sql = "update tbl_reportes set ruta_reportes=? where pk_id_reportes=?";
                 OdbcCommand cmd = new OdbcCommand(sql, con);
@@ -49,7 +51,8 @@ namespace Capa_Modelo_Reporteador
 
             try
             {
-                using (OdbcConnection con = Conexion.ObtenerConexion())
+                Conexion cn = new Conexion();
+                using (OdbcConnection con = cn.conexion())
                 {
                     string sql = "SELECT pk_id_reportes, titulo_reportes, ruta_reportes, fecha_reportes FROM tbl_reportes";
                     OdbcDataAdapter da = new OdbcDataAdapter(sql, con);
@@ -67,6 +70,5 @@ namespace Capa_Modelo_Reporteador
 
 
         // Fin de código de: Rocio Lopez con carné: 9959-23-740 en la fecha de: 11/09/2025
-
     }
 }


### PR DESCRIPTION
Se reemplazó la llamada a Conexion.ObtenerConexion() por la creación de una instancia de Conexion para manejar correctamente la conexión ODBC.

Nuevo:
Conexion cn = new Conexion();
using (OdbcConnection con = cn.conexion())

**Paula Leonardo - 11/09/2025**